### PR TITLE
Add Separated Profiles List Files

### DIFF
--- a/resources/core-profiles.json
+++ b/resources/core-profiles.json
@@ -1,0 +1,19 @@
+[
+    {
+      "identifier": "basic",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/basic.json"
+    },
+    {
+      "identifier": "full",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/full.json"
+    },
+    {
+      "identifier": "product",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/product.json"
+    },
+    {
+      "identifier": "project",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/project.json"
+    }
+  ]
+  

--- a/resources/nggdpp-profiles.json
+++ b/resources/nggdpp-profiles.json
@@ -1,0 +1,23 @@
+[
+    {
+      "identifier": "nggdpp-common",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/nggdpp-common.json"
+    },
+    {
+      "identifier": "nggdpp-geological",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/nggdpp-geological.json"
+    },
+    {
+      "identifier": "nggdpp-image",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/nggdpp-image.json"
+    },
+    {
+      "identifier": "nggdpp-invertebrate",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/nggdpp-invertebrate.json"
+    },
+    {
+      "identifier": "nggdpp-vertebrate",
+      "url": "https://cdn.jsdelivr.net/gh/adiwg/mdProfiles@master/resources/profiles/nggdpp-vertebrate.json"
+    }
+  ]
+  


### PR DESCRIPTION
Closes #40, closes #50 

Changes:
2 new files:
* core-profiles.json contains the default/core profiles for mdEditor. 
* nggdpp-profiles.json contains the NGGDPP specific profiles that need to be moved to a separate repository.

This will not break any existing functionality required by mdEditor or mdKeywords.